### PR TITLE
Add DAD Stakes Pool

### DIFF
--- a/cardano-mdp.json
+++ b/cardano-mdp.json
@@ -314,6 +314,11 @@
                "pool_id": "0688dfbb3c11169ab8cd98cb7f00ddff3cc8d915c297adfb8484de3d",
                "member_since": "2021-03-28",
                "name": "[GR8FL] Grateful Pool"
+            },
+            "58": {
+               "pool_id": "dad893073815ca8b225554a2fc5048e366bd65938551323fc13cf7f5",
+               "member_since": "2021-04-13",
+               "name": "[DAD] Stakes Pool"
             }
         }
     }


### PR DESCRIPTION
DAD Stakes Pool will be donating 15% of our profits to help fight the absence of father crisis. No ROA yet, but we should mint our first block on the 15th!