### PR TITLE
Changed ticker - CB1 to CBROS

### DIFF
--- a/cardano-mdp.json
+++ b/cardano-mdp.json
@@ -506,7 +506,7 @@
             "96": {    
                "pool_id": "74d66da57368e12f12bd07f303da7f8cd3c2494af9e32e4dea210c58",
                "member_since": "2021-07-19",
-               "name": "[CB1] Coudre Bros"
+               "name": "[CBROS] Coudre Bros"
             },
             "97": {    
                "pool_id": "abea730f5c32157c76c876597d0b7093d50754d0274d67c62d7434b9",


### PR DESCRIPTION
Hi SPOs! After careful considerations we have decided to change the pool ticker from CB1 to CBROS.
The main reason is that an old ticker may be misinterpreted as one of the tickers of multiple stake pools.